### PR TITLE
Set up updatecli

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,34 @@
+name: updatecli
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: '0 6 * * *'
+permissions:
+  contents: read
+
+jobs:
+  compose:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: --experimental compose diff
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: --experimental compose apply
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}

--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -1,0 +1,13 @@
+# Config file for `updatecli compose ...`.
+# https://www.updatecli.io/docs/core/compose/
+policies:
+  - name: Handle default oblt-cli version
+    policy: ghcr.io/elastic/oblt-updatecli-policies/oblt-cli/version:0.1.0@sha256:b62a81ac2ad56ae9c45e76a1b6e11d990d7fbc7d367285bbec2601836cc570f9
+    values:
+      - updatecli/values.d/scm.yml
+      - updatecli/values.d/oblt-cli.yml
+  - name: Update Updatecli policies
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.4.0@sha256:254367f5b1454fd6032b88b314450cd3b6d5e8d5b6c953eb242a6464105eb869
+    values:
+      - updatecli/values.d/scm.yml
+      - updatecli/values.d/update-compose.yml

--- a/updatecli/values.d/oblt-cli.yml
+++ b/updatecli/values.d/oblt-cli.yml
@@ -1,0 +1,1 @@
+path: .default-oblt-cli-version

--- a/updatecli/values.d/scm.yml
+++ b/updatecli/values.d/scm.yml
@@ -1,0 +1,11 @@
+scm:
+  enabled: true
+  owner: elastic
+  repository: oblt-cli-buildkite-plugin
+  branch: main
+  # begin update-compose policy values
+  user: obltmachine
+  email: obltmachine@users.noreply.github.com
+  # end update-compose policy values
+
+signedcommit: true

--- a/updatecli/values.d/update-compose.yml
+++ b/updatecli/values.d/update-compose.yml
@@ -1,0 +1,3 @@
+spec:
+  files:
+    - "update-compose.yaml"


### PR DESCRIPTION
Set up updatecli and add the oblt-cli/version and autodiscovery policies.

This will make updatecli update the oblt-cli version defined in `.default-oblt-cli-version` and update the policies defined in `update-compose.yml`

- the secret `UPDATECLI_GH_TOKEN` was added and this repository was added to its permissions.
- access to the oblt-cli/version packaged was granted
