### PR TITLE
Use `version-file` input for E2E test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       provider: gcp
     plugins:
       - elastic/oblt-cli#${BUILDKITE_COMMIT}:
-          version-file: .oblt-cli-version
+          version-file: .default-oblt-cli-version
     command: .buildkite/scripts/create-cluster.sh
 
   - label: "E2E - Get cluster name"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ steps:
       provider: gcp
     plugins:
       - elastic/oblt-cli#${BUILDKITE_COMMIT}:
-          version: 7.3.0
           version-file: .oblt-cli-version
     command: .buildkite/scripts/create-cluster.sh
 


### PR DESCRIPTION
## Context

Both the `version` and `version-file` inputs were there to test the precedence.

But the precedence is actually tested in unit-tests as well. Hence, it's better to test the version-file so the latest version is tested in the E2E test.

## What Changed

I am removing the `version` input, so that the `version-file` input is used in the E2E test.
